### PR TITLE
Adding Reload button for external changes and notification

### DIFF
--- a/R/mod_import.R
+++ b/R/mod_import.R
@@ -221,7 +221,7 @@ mod_import_server <- function(id, r, DROPDOWNS) {
       showModal(
         modalDialog(
           title = "Reload Project",
-          "Your changes will be lost, are you sure?",
+          "Your changes will be lost. Are you sure?",
           footer = tagList(
             actionButton(ns("confirm_reload"), "Yes"),
             modalButton("No")


### PR DESCRIPTION
feature Add explicit reload project button to fix data refresh issue #196

This implementation adds a "Reload Project" button that allows users to
force re-read Excel configuration files when they have been modified
externally, addressing the issue where Shiny's reactive system doesn't
detect changes when the same file path is selected.

Key Changes:
- Added reload button UI in mod_import_ui() with sync icon
- Implemented reloadProject() function that:
  * Checks if project is loaded before attempting reload
  * Re-reads all Excel files from current file paths
  * Resets $modified data to match new $original data
  * Clears warnings and updates all dropdowns
  * Provides success/error notifications to user
- Added observeEvent() to handle button clicks

Will Resolve #196